### PR TITLE
Optional etag flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
            ,'))))))))))))))), /{
       '  ,'o  ))))))))))))))))={
          >    )))Sebastes)))))={
-         `,   ))))))\ \)))))))={     
+         `,   ))))))\ \)))))))={
            ',))))))))\/)))))' \{
              '*O))))))))O*'
 
@@ -204,13 +204,19 @@ if __name__ == '__main__':
 Some Redfish endpoints support patching. The link_patch method will call a passed link object and get it’s Etag value (if there is any) and then will perform a patch request with passed payload data.
 
 ```python
-def link_patch(self, link: Link, payload: typing.Optional[dict] = None) -> dict:
-    """
-    Call Patch request on specific link model
-    :param link: Model to patch
-    :param payload: Patch data
-    :return: JSON response data
-    """
+    def link_patch(self,
+                   link: Link,
+                   payload: typing.Optional[dict] = None,
+                   pass_etag: bool = True
+                   ) -> dict:
+        """
+        Call Patch request on specific link model
+        :param link: Model to patch
+        :param payload: Patch data
+        :param pass_etag: boolean flag, is set as true, will attempt to
+        use resource ETag value in PATCH request.
+        :return: JSON response data
+        """
     ...
 ```
 

--- a/sebastes/processor/common.py
+++ b/sebastes/processor/common.py
@@ -77,11 +77,17 @@ class DataManager:
         self._username = username
         self._password = password
 
-    def link_patch(self, link: Link, payload: typing.Optional[dict] = None) -> dict:
+    def link_patch(self,
+                   link: Link,
+                   payload: typing.Optional[dict] = None,
+                   pass_etag: bool = True
+                   ) -> dict:
         """
         Call Patch request on specific link model
         :param link: Model to patch
         :param payload: Patch data
+        :param pass_etag: boolean flag, is set as true, will attempt to
+        use resource ETag value in PATCH request.
         :return: JSON response data
         """
         if payload is None:
@@ -90,22 +96,22 @@ class DataManager:
         base_url = f"https://{self._hostname}"
         url = f'{base_url}{link.odata_id}'
 
-        get_response = requests.get(
-            url=url,
-            headers=headers,
-            verify=False,
-            auth=(
-                self._username,
-                self._password
+        if pass_etag is True:
+            get_response = requests.get(
+                url=url,
+                headers=headers,
+                verify=False,
+                auth=(
+                    self._username,
+                    self._password
+                )
             )
-        )
-        if get_response.ok:
-            etag = get_response.headers.get('etag')
-            if etag is not None:
-                headers['If-Match'] = etag
-            print(headers)
-        else:
-            raise Exception(get_response.content.decode())
+            if get_response.ok:
+                etag = get_response.headers.get('etag')
+                if etag is not None:
+                    headers['If-Match'] = etag
+            else:
+                raise Exception(get_response.content.decode())
 
         response = requests.patch(
             url=url,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sebastes
-version = 0.1.1
+version = 0.1.2
 url = https://github.com/YADRO-KNS/sebastes
 license = MIT License
 author = Sergey Parshin


### PR DESCRIPTION
As it turns out, some redfish implementations do not require conditional headers with Etag value during PATCH request. For such cases in **link_patch** method of **DataManager** added pass_etag parameter (default is True). If set as true, DataManager will perform GET request for target resource and will attempt to use Etag value from headers. Otherwise the PATCH request will be called right ahead without the If-Match header.