### PR TITLE
4 managers endpoint is not processed correctly

### DIFF
--- a/sebastes/parser/parser.py
+++ b/sebastes/parser/parser.py
@@ -60,8 +60,10 @@ category_fields: typing.Dict[DataModelCategory, typing.List[str]] = {
 optional_fields: typing.Dict[DataModelCategory, typing.List[str]] = {
     DataModelCategory.LINK: [],
     DataModelCategory.ACTION: ['redfish_action_info'],
-    DataModelCategory.RESOURCE: ['id', 'odata_context', 'description', 'name'],
-    DataModelCategory.COLLECTION: ['id', 'odata_context', 'description', 'name', 'members_odata_next_link'],
+    DataModelCategory.RESOURCE: ['id', 'odata_context', 'description', 'name', 'odata_etag'],
+    DataModelCategory.COLLECTION: [
+        'id', 'odata_context', 'description', 'name', 'odata_etag', 'members_odata_next_link'
+    ]
 }
 
 
@@ -71,6 +73,7 @@ class CustomDataModel(BaseModel):
     """
 
     _replace_words = [
+        ('_odata_etag', 'odata_etag'),
         ('_odata_id', 'odata_id'),
         ('_odata_context', 'odata_context'),
         ('_odata_type', 'odata_type'),

--- a/sebastes/processor/common.py
+++ b/sebastes/processor/common.py
@@ -33,6 +33,7 @@ class Resource(Link):
 
     _url: str
     odata_type: str = pydantic.Field(..., alias='@odata.type')
+    odata_etag: typing.Optional[str] = pydantic.Field(None, alias='@odata.etag')
     name: typing.Optional[str] = pydantic.Field(None, alias='Name')
     id: typing.Optional[str] = pydantic.Field(None, alias='Id')
     odata_context: typing.Optional[str] = pydantic.Field(None, alias='@odata.context')

--- a/sebastes/scanner/scanner.py
+++ b/sebastes/scanner/scanner.py
@@ -156,7 +156,7 @@ class RedfishData:
 
     def __eq__(self, other: typing.Any) -> bool:
         if isinstance(other, self.__class__):
-            return other.full_name == self.full_name
+            return other.full_name == self.full_name and other.parent == self.parent
         else:
             return False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sebastes
-version = 0.1.3
+version = 0.1.4
 url = https://github.com/YADRO-KNS/sebastes
 license = MIT License
 author = Sergey Parshin


### PR DESCRIPTION
As it turns out some vendors reuse model names in different sections of Redfish tree. As a result Scanner ignored second and following models, since there already was one in the collection. To fix this issue Redfish models equality criteria was updated. Not only does a model's full name play a role now, but it’s parent as well.
Also added optional odata_etag field for Resource and Collection models.